### PR TITLE
Update Redis dependency to ddev/ddev-redis

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -11,7 +11,7 @@ project_files:
 
 # List of add-on names that this add-on depends on
 dependencies:
-  - redis
+  - ddev/ddev-redis
 
 # DDEV environment variables can be interpolated into these actions.
 # post_install_actions are executed in the context of the target project's .ddev directory.


### PR DESCRIPTION
In upcoming DDEV version v1.24.8, `ddev add-on get` will try to download dependencies, so the `dependencies` list has to show where the dependencies can come from. Please pull this and make a new release, thanks!